### PR TITLE
ViewDataBinding 의 binding 방식 변경 제안

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity android:name=".SampleActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/king_bob_nae/MainActivity.kt
+++ b/app/src/main/java/com/example/king_bob_nae/MainActivity.kt
@@ -7,5 +7,8 @@ import com.example.king_bob_nae.databinding.ActivityMainBinding
 class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        SampleActivity.obtain(this).also {
+            startActivity(it)
+        }
     }
 }

--- a/app/src/main/java/com/example/king_bob_nae/SampleActivity.kt
+++ b/app/src/main/java/com/example/king_bob_nae/SampleActivity.kt
@@ -1,0 +1,30 @@
+package com.example.king_bob_nae
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.commit
+import com.example.king_bob_nae.base.viewDataBinding
+import com.example.king_bob_nae.databinding.ActivitySampleBinding
+
+class SampleActivity : AppCompatActivity() {
+
+    private val binding by viewDataBinding<ActivitySampleBinding>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_sample)
+        binding.btnHelloWorld.setOnClickListener {
+            supportFragmentManager.commit {
+                replace(android.R.id.content, SampleFragment())
+            }
+        }
+    }
+
+    companion object {
+        fun obtain(context: Context): Intent {
+            return Intent(context, SampleActivity::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/example/king_bob_nae/SampleFragment.kt
+++ b/app/src/main/java/com/example/king_bob_nae/SampleFragment.kt
@@ -1,0 +1,27 @@
+package com.example.king_bob_nae
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.example.king_bob_nae.base.viewDataBinding
+import com.example.king_bob_nae.databinding.FragmentSampleBinding
+
+class SampleFragment : Fragment() {
+
+    private val binding by viewDataBinding<FragmentSampleBinding>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_sample, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.tvSampleFragment.text = "샘플 프래그먼트입니다"
+    }
+}

--- a/app/src/main/java/com/example/king_bob_nae/base/ViewDataBindingDelegate.kt
+++ b/app/src/main/java/com/example/king_bob_nae/base/ViewDataBindingDelegate.kt
@@ -1,0 +1,94 @@
+package com.example.king_bob_nae.base
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.databinding.ViewDataBinding
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+class ActivityViewDataBindingDelegate<T : ViewDataBinding>(
+    bindingClass: Class<T>,
+    private val activity: ComponentActivity
+) : ReadOnlyProperty<ComponentActivity, T> {
+
+    private var binding: T? = null
+    private val bindMethod = bindingClass.getMethod("bind", View::class.java)
+
+    init {
+        activity.lifecycle.addObserver(object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                if (event == Lifecycle.Event.ON_DESTROY) {
+                    activity.lifecycleScope.launch(Dispatchers.Main) {
+                        binding?.unbind()
+                        binding = null
+                    }
+                }
+            }
+        })
+    }
+
+    override fun getValue(thisRef: ComponentActivity, property: KProperty<*>): T {
+        if (thisRef.lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED).not()) {
+            error("Cannot access view bindings. Activity lifecycle is ${thisRef.lifecycle.currentState}!")
+        }
+
+        binding?.let { return it }
+        val root = thisRef.window?.decorView?.findViewById<ViewGroup>(android.R.id.content)?.getChildAt(0)
+        binding = (bindMethod.invoke(null, root) as T).also { binding ->
+            binding.lifecycleOwner = thisRef
+        }
+
+        return binding!!
+    }
+}
+
+class FragmentViewDataBindingDelegate<T : ViewDataBinding>(
+    bindingClass: Class<T>,
+    private val fragment: Fragment
+) : ReadOnlyProperty<Fragment, T> {
+    private var binding: T? = null
+
+    private val bindMethod = bindingClass.getMethod("bind", View::class.java)
+
+    init {
+        fragment.lifecycle.addObserver(object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                if (event == Lifecycle.Event.ON_DESTROY) {
+                    fragment.lifecycleScope.launch(Dispatchers.Main) {
+                        binding?.unbind()
+                        binding = null
+                    }
+                }
+            }
+        })
+    }
+
+    override fun getValue(thisRef: Fragment, property: KProperty<*>): T {
+        // onCreateView may be called between onDestroyView and next Main thread cycle.
+        // In this case [binding] refers to the previous fragment view. Check that binding's root view matches current fragment view
+        if (binding != null && binding?.root !== thisRef.view) {
+            binding = null
+        }
+        binding?.let { return it }
+
+        val lifecycle = fragment.viewLifecycleOwner.lifecycle
+        if (!lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)) {
+            error("Cannot access view bindings. View lifecycle is ${lifecycle.currentState}!")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        binding = bindMethod.invoke(null, thisRef.requireView()) as T
+        return binding!!
+    }
+}
+
+inline fun <reified T : ViewDataBinding> ComponentActivity.viewDataBinding() =
+    ActivityViewDataBindingDelegate(T::class.java, this)
+
+inline fun <reified T : ViewDataBinding> Fragment.viewDataBinding() = FragmentViewDataBindingDelegate(T::class.java, this)

--- a/app/src/main/res/layout/activity_sample.xml
+++ b/app/src/main/res/layout/activity_sample.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".SampleActivity">
+
+        <Button
+            android:id="@+id/btnHelloWorld"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Hello World!"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_sample.xml
+++ b/app/src/main/res/layout/fragment_sample.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/white">
+
+        <TextView
+            android:id="@+id/tvSampleFragment"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="This is sample fragment"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
# 아이디어
- [Mavericks 코드](https://github.com/airbnb/mavericks/tree/e8a631a19fc1b044da3ddff358712e129dc487a6/view-binding-utils/src/main/java/com/airbnb/mvrx/viewbinding)를 참고하여 data binding 또한 read only property 로 부르면 편하지 않을까 싶어 제안합니다.
- Activity 와 Fragment 의 Base 코드가 생기는 것을 최대한 막습니다. 이는 추후에 스파게티 코드가 될 여지가 있기 떄문입니다.
- bind / unbind 를 lifecycle 에 직접적으로 넣어주는 것이 아니라 addObserver 를 통해 자동으로 하도록 변경합니다.


# 사용방법
## Activity
- setContentView 에 layoutId 를 넣습니다.
- 그 후부터 viewDataBinding field 가 사용 가능합니다. (setContentView 전에 viewDataBinding field 불리게 된다면 bind 가 되어있지 않아 에러를 뱉습니다.)
```kotlin
class SampleActivity : AppCompatActivity() {

    private val binding by viewDataBinding<ActivitySampleBinding>()

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.activity_sample)
        binding.btnHelloWorld.setOnClickListener {
            supportFragmentManager.commit {
                replace(android.R.id.content, SampleFragment())
            }
        }
    }
}
```
## Fragment
- onCreateView 메소드를 구현합니다.
- onViewCreated 부터 viewDataBinding field 가 사용 가능합니다. (onViewCreated 전에 viewDataBinding field 불리게 된다면 bind 가 되어있지 않아 에러를 뱉습니다.)
```kotlin
class SampleFragment : Fragment() {

    private val binding by viewDataBinding<FragmentSampleBinding>()

    override fun onCreateView(
        inflater: LayoutInflater,
        container: ViewGroup?,
        savedInstanceState: Bundle?
    ): View? {
        return inflater.inflate(R.layout.fragment_sample, container, false)
    }

    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
        super.onViewCreated(view, savedInstanceState)
        binding.tvSampleFragment.text = "샘플 프래그먼트입니다"
    }
}

```

# 이 PR 이 채택되지 않더라도
- 굳이 ReadOnlyProperty 로 쓰지 않더라도 binding 을 괸리하는 interface 를 하나 만드는 것을 추천합니다.
- 테스트 코드를 작성하게 된다면 테스트에 용이해질 것입니다.